### PR TITLE
Resize content 

### DIFF
--- a/styles/global.less
+++ b/styles/global.less
@@ -11,7 +11,7 @@ body {
   #app {
     position: relative;
     margin: 40px auto;
-    width: 550px;
+    width: 70%;
   }
 }
 

--- a/styles/item.less
+++ b/styles/item.less
@@ -12,7 +12,7 @@
   box-sizing: border-box;
   font-size: @item-font-size;
   .item-name {
-    width: 400px;
+    width: 75%;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;


### PR DESCRIPTION
Hello!

While using the app, I noticed that when an item is too long, only a part of it is visible. I updated some style values to make them relative to the size of the window.

Here are two screenshots showing the result:

**Default size**
![1](https://cloud.githubusercontent.com/assets/1284036/25790340/a817a346-336c-11e7-9580-35f657bcede6.png)

**New size**
![2](https://cloud.githubusercontent.com/assets/1284036/25790341/a82ce3be-336c-11e7-983b-cc592ea09f6e.png)



