### PR TITLE
Development process and Styles issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 main.css
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@
 A meter-based to-do list built with Electron, React, Redux, and LESS.
 
 ![todometer](assets/screenshot.png)
+
+### Development
+
+* Clone the repo via `git clone https://github.com/cassidoo/todometer.git`
+* Go to the project directory and install dependencies: `cd todometer && npm install`
+* Start developing by `npm start`. This will show an electron window with your application's build.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "repository": "github.com/cassidoo/todometer",
   "scripts": {
-    "start": "electron .",
+    "start": "npm run build:less && electron .",
     "build:less": "lessc styles/global.less main.css",
     "package-mac": "electron-packager . --overwrite --platform=darwin --arch=x64 --icon=assets/mac/icon.png.icns --prune=true --out=release-builds",
     "package-win": "electron-packager . --overwrite --asar=true --platform=win32 --arch=ia32 --icon=assets/win/icon.png.ico --prune=true --out=release-builds --version-string.CompanyName=CE --version-string.FileDescription=CE",


### PR DESCRIPTION
When I cloned the project and started developing, the 1st build after running `npm start` did not load any styles. I was so confused. Then dogged in and found that LESS files should be built into `.css`. There were no rules for that on development.
Added to help devs and contributors do their job easily.