### PR TITLE
Items wrap long text

### DIFF
--- a/styles/item.less
+++ b/styles/item.less
@@ -3,9 +3,9 @@
   align-items: center;
   justify-content: space-between;
   margin: 0 0 10px 0;
-  padding: 0 20px;
+  padding: 10px 20px;
   width: 100%;
-  height: 70px;
+  // height: 70px;
   background: @item-color;
   border: none;
   border-radius: 3px;
@@ -13,9 +13,10 @@
   font-size: @item-font-size;
   .item-name {
     width: 400px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
+    word-break: break-all;
+    &:first-letter {
+      text-transform: uppercase;
+    }
   }
   .buttons button {
     position: relative;

--- a/styles/item.less
+++ b/styles/item.less
@@ -3,9 +3,9 @@
   align-items: center;
   justify-content: space-between;
   margin: 0 0 10px 0;
-  padding: 10px 20px;
+  padding: 20px;
   width: 100%;
-  // height: 70px;
+  min-height: 70px;
   background: @item-color;
   border: none;
   border-radius: 3px;
@@ -14,9 +14,6 @@
   .item-name {
     width: 400px;
     word-break: break-all;
-    &:first-letter {
-      text-transform: uppercase;
-    }
   }
   .buttons button {
     position: relative;


### PR DESCRIPTION
Added styles to wrap very long texts.

Now my todometer looks like below on long-text items:

![longtext](https://image.ibb.co/gXMcGQ/wrap.png)