### PR TITLE
Draggable todos

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,9 @@
   ],
   "extends": ["eslint:recommended", "plugin:react/recommended"],
   "rules": {
-    "no-console": ["warn", { allow: ["error"] }],
-    "no-undef": "off"
+    "no-console": ["warn", { "allow": ["error"] }],
+    "no-undef": "off",
+    "react/prop-types": "off",
+    "no-extra-boolean-cast": "off"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 main.css
 npm-debug.log
+yarn.lock

--- a/assets/handle.svg
+++ b/assets/handle.svg
@@ -1,0 +1,15 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <!-- Generator: Sketch 42 (36781) - http://www.bohemiancoding.com/sketch -->
+ <title>Group</title>
+ <desc>Created with Sketch.</desc>
+
+ <g>
+  <title>background</title>
+  <rect fill="none" id="canvas_background" height="24" width="24" y="-1" x="-1"/>
+ </g>
+ <g fill="#FFFFFF">
+  <rect stroke="null" height="4" width="4" y="3" x="10" id="Rectangle-3"/>
+  <rect stroke="null" height="4" width="4" y="10" x="10" id="svg_1"/>
+  <rect stroke="null" height="4" width="4" y="17" x="10" id="svg_2"/>
+ </g>
+</svg>

--- a/main.js
+++ b/main.js
@@ -56,13 +56,11 @@ function menuSetup() {
         },
         {
           type: 'separator'
-        /* For debugging
         }, {
           label: 'Dev tools',
           click: () => {
             mainWindow.webContents.openDevTools();
           }
-          */
         },
         {
           label: 'Quit',

--- a/main.js
+++ b/main.js
@@ -56,11 +56,13 @@ function menuSetup() {
         },
         {
           type: 'separator'
+        /* For debugging
         }, {
           label: 'Dev tools',
           click: () => {
             mainWindow.webContents.openDevTools();
           }
+          */
         },
         {
           label: 'Quit',

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-register": "^6.3.13",
     "moment": "^2.17.1",
     "react": "^15.3.2",
+    "react-beautiful-dnd": "6.0.2",
     "react-dom": "^15.3.2",
     "react-progressbar.js": "^0.2.0",
     "react-redux": "^5.0.2",

--- a/styles/item.less
+++ b/styles/item.less
@@ -12,8 +12,18 @@
   box-sizing: border-box;
   font-size: @item-font-size;
   .item-name {
-    width: 400px;
+    width: 394px;
     word-break: break-all;
+  }
+  .handle {
+    width: 24px;
+    border: none;
+    height: 24px;
+    margin-left: -16px;
+    background: no-repeat url('./assets/handle.svg');
+    &:after {
+      background: @red;
+    }
   }
   .buttons button {
     position: relative;

--- a/styles/item.less
+++ b/styles/item.less
@@ -29,6 +29,7 @@
     position: relative;
     margin: 0 0 0 10px;
     height: 24px;
+    width: 108;
     border: none;
     &.delete {
       width: 24px;

--- a/styles/item.less
+++ b/styles/item.less
@@ -25,11 +25,13 @@
       background: @red;
     }
   }
+  .buttons {
+    width: 108px;
+  }
   .buttons button {
     position: relative;
     margin: 0 0 0 10px;
     height: 24px;
-    width: 108;
     border: none;
     &.delete {
       width: 24px;

--- a/views/actions.js
+++ b/views/actions.js
@@ -10,7 +10,7 @@ export const SET_DATE = 'SET_DATE';
 export const addItem = item => ({ type: ADD_ITEM, item });
 export const updateItem = item => ({ type: UPDATE_ITEM, item });
 export const deleteItem = item => ({ type: DELETE_ITEM, item });
-export const reorderItem = (startIndex, endIndex) => ({ type: REORDER_ITEM, startIndex, endIndex });
+export const reorderItem = (source, destination) => ({ type: REORDER_ITEM, source, destination });
 
 export const resetAll = () => ({ type: RESET_ALL });
 

--- a/views/actions.js
+++ b/views/actions.js
@@ -1,6 +1,7 @@
 export const ADD_ITEM = 'ADD_ITEM';
 export const UPDATE_ITEM = 'UPDATE_ITEM';
 export const DELETE_ITEM = 'DELETE_ITEM';
+export const REORDER_ITEM = 'REORDER_ITEM';
 
 export const RESET_ALL = 'RESET_ALL';
 
@@ -9,6 +10,7 @@ export const SET_DATE = 'SET_DATE';
 export const addItem = item => ({ type: ADD_ITEM, item });
 export const updateItem = item => ({ type: UPDATE_ITEM, item });
 export const deleteItem = item => ({ type: DELETE_ITEM, item });
+export const reorderItem = (startIndex, endIndex) => ({ type: REORDER_ITEM, startIndex, endIndex });
 
 export const resetAll = () => ({ type: RESET_ALL });
 

--- a/views/components/Item.jsx
+++ b/views/components/Item.jsx
@@ -24,6 +24,7 @@ export default class Item extends React.Component {
   render() {
     return (
       <div className="item">
+        <div className="handle" {...this.props.dragHandleProps}></div>
         <div className="item-name">{this.props.text}</div>
         {this.renderButtons()}
       </div>

--- a/views/components/ItemList.jsx
+++ b/views/components/ItemList.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { addItem, updateItem, deleteItem, resetAll } from '../actions.js';
+import { addItem, updateItem, deleteItem, reorderItem, resetAll } from '../actions.js';
 import { getAllItems, getPendingItems, getCompletedItems, getPausedItems } from '../reducers/item-list.js';
 import Item from './Item';
 import Progress from './Progress';
@@ -14,6 +14,7 @@ class ItemList extends React.Component {
     this.addItem = this.addItem.bind(this);
     this.completeItem = this.completeItem.bind(this);
     this.pauseItem = this.pauseItem.bind(this);
+    this.onDragEnd = this.onDragEnd.bind(this);
   }
 
   addItem(e) {
@@ -103,13 +104,18 @@ class ItemList extends React.Component {
     }
   }
 
-  onDragEnd() {
-    // TODO
+  onDragEnd(result) {
+    console.log('result: ', result);
+    // dropped outside the list
+    if (!result.destination) {
+      return;
+    }
+
+    this.props.reorderItem(result.source.index, result.destination.index);
   }
 
   render() {
     const { pendingItems } = this.props;
-    console.log(pendingItems);
     return (
       <div className="item-list">
         {this.renderProgress()}
@@ -136,16 +142,18 @@ class ItemList extends React.Component {
                             ref={provided.innerRef}
                             {...provided.draggableProps}
                           >
-                            <Item
-                              item={item}
-                              text={item.text}
-                              status={item.status}
-                              key={item.key}
-                              onComplete={this.completeItem}
-                              onDelete={this.props.deleteItem}
-                              onPause={this.pauseItem}
-                              dragHandleProps={provided.dragHandleProps}
-                            />
+                            <div style={{ height: '100%' }}>
+                              <Item
+                                item={item}
+                                text={item.text}
+                                status={item.status}
+                                key={item.key}
+                                onComplete={this.completeItem}
+                                onDelete={this.props.deleteItem}
+                                onPause={this.pauseItem}
+                                dragHandleProps={provided.dragHandleProps}
+                              />
+                            </div>
                           </div>
                           {provided.placeholder}
                         </div>
@@ -174,7 +182,8 @@ const mapDispatchToProps = dispatch => ({
   addItem: item => dispatch(addItem(item)),
   updateItem: item => dispatch(updateItem(item)),
   deleteItem: item => dispatch(deleteItem(item)),
-  resetAll: item => dispatch(resetAll(item))
+  reorderItem: (startIndex, endIndex) => dispatch(reorderItem(startIndex, endIndex)),
+  resetAll: item => dispatch(resetAll(item)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ItemList);

--- a/views/components/ItemList.jsx
+++ b/views/components/ItemList.jsx
@@ -141,9 +141,9 @@ class ItemList extends React.Component {
           { pausedItems.length > 0 && 
           <div>
             <h2 style={{ margin: 0 }}>Do Later</h2>
-            <Droppable droppableId="paused">
+            <Droppable droppableId="paused" ignoreContainerClipping>
               {(droppableProvided) => (
-                <div ref={droppableProvided.innerRef} >
+                <div ref={droppableProvided.innerRef}>
                   <div style={{ height: 20 }} />
                   {this.renderItems(pausedItems)}
                   {droppableProvided.placeholder}

--- a/views/components/ItemList.jsx
+++ b/views/components/ItemList.jsx
@@ -96,7 +96,7 @@ class ItemList extends React.Component {
                   key={item.key}
                   onComplete={this.completeItem}
                   onDelete={this.props.deleteItem}
-                  paused={true}
+                  paused={item.status === 'paused'}
                   dragHandleProps={draggableProvided.dragHandleProps}
                 />
                 </div>
@@ -132,34 +132,30 @@ class ItemList extends React.Component {
             />
             <button type="submit" />
           </form>
-          <div>
-            <Droppable droppableId="pending">
-              {(droppableProvided) => (
-                <div
-                  ref={droppableProvided.innerRef}
-                >
-                  {this.renderItems(pendingItems)}
-                  {droppableProvided.placeholder}
-                </div>
-              )}
-            </Droppable>
-            <div>
-              <h2>Do Later</h2>
-              <Droppable droppableId="paused">
-                {(droppableProvided) => (
-                  <div
-                    ref={droppableProvided.innerRef}
-                  >
-                    {this.renderItems(pausedItems)}
-                    {droppableProvided.placeholder}
-                  </div>
-                )}
-              </Droppable>
-            </div>
+          <Droppable droppableId="pending">
+            {(droppableProvided) => (
+              <div
+                ref={droppableProvided.innerRef}
+              >
+                {this.renderItems(pendingItems)}
+                {droppableProvided.placeholder}
+              </div>
+            )}
+          </Droppable>
+          <h2>Do Later</h2>
+          <Droppable droppableId="paused">
+            {(droppableProvided) => (
+              <div
+                ref={droppableProvided.innerRef}
+              >
+                {this.renderItems(pausedItems)}
+                {droppableProvided.placeholder}
+              </div>
+            )}
+          </Droppable>
           {this.renderReset()}
         </div>
-      </div>
-    </DragDropContext>
+      </DragDropContext>
     );
   }
 }

--- a/views/components/ItemList.jsx
+++ b/views/components/ItemList.jsx
@@ -96,6 +96,7 @@ class ItemList extends React.Component {
                     key={item.key}
                     onComplete={this.completeItem}
                     onDelete={this.props.deleteItem}
+                    onPause={this.pauseItem}
                     paused={item.status === 'paused'}
                     dragHandleProps={draggableProvided.dragHandleProps}
                   />

--- a/views/components/ItemList.jsx
+++ b/views/components/ItemList.jsx
@@ -88,17 +88,17 @@ class ItemList extends React.Component {
                 ref={draggableProvided.innerRef}
                 {...draggableProvided.draggableProps}
               >
-              <div style={{ height: '100%' }}>
-                <Item
-                  item={item}
-                  text={item.text}
-                  status={item.status}
-                  key={item.key}
-                  onComplete={this.completeItem}
-                  onDelete={this.props.deleteItem}
-                  paused={item.status === 'paused'}
-                  dragHandleProps={draggableProvided.dragHandleProps}
-                />
+                <div style={{ height: '100%' }}>
+                  <Item
+                    item={item}
+                    text={item.text}
+                    status={item.status}
+                    key={item.key}
+                    onComplete={this.completeItem}
+                    onDelete={this.props.deleteItem}
+                    paused={item.status === 'paused'}
+                    dragHandleProps={draggableProvided.dragHandleProps}
+                  />
                 </div>
               </div>
               {draggableProvided.placeholder}

--- a/views/components/ItemList.jsx
+++ b/views/components/ItemList.jsx
@@ -137,16 +137,20 @@ class ItemList extends React.Component {
               </div>
             )}
           </Droppable>
-          <h2 style={{ margin: 0 }}>Do Later</h2>
-          <Droppable droppableId="paused">
-            {(droppableProvided) => (
-              <div ref={droppableProvided.innerRef} >
-                <div style={{ height: 20 }} />
-                {this.renderItems(pausedItems)}
-                {droppableProvided.placeholder}
-              </div>
-            )}
-          </Droppable>
+          { pausedItems.length > 0 && 
+          <div>
+            <h2 style={{ margin: 0 }}>Do Later</h2>
+            <Droppable droppableId="paused">
+              {(droppableProvided) => (
+                <div ref={droppableProvided.innerRef} >
+                  <div style={{ height: 20 }} />
+                  {this.renderItems(pausedItems)}
+                  {droppableProvided.placeholder}
+                </div>
+              )}
+            </Droppable>
+          </div>
+          }
           {this.renderReset()}
         </div>
       </DragDropContext>

--- a/views/components/ItemList.jsx
+++ b/views/components/ItemList.jsx
@@ -6,6 +6,7 @@ import { addItem, updateItem, deleteItem, resetAll } from '../actions.js';
 import { getAllItems, getPendingItems, getCompletedItems, getPausedItems } from '../reducers/item-list.js';
 import Item from './Item';
 import Progress from './Progress';
+import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 
 class ItemList extends React.Component {
   constructor(props) {
@@ -102,8 +103,13 @@ class ItemList extends React.Component {
     }
   }
 
+  onDragEnd() {
+    // TODO
+  }
+
   render() {
     const { pendingItems } = this.props;
+    console.log(pendingItems);
     return (
       <div className="item-list">
         {this.renderProgress()}
@@ -115,21 +121,41 @@ class ItemList extends React.Component {
           />
           <button type="submit" />
         </form>
-        {
-          pendingItems && pendingItems.map(item => {
-            return (
-              <Item
-                item={item}
-                text={item.text}
-                status={item.status}
-                key={item.key}
-                onComplete={this.completeItem}
-                onDelete={this.props.deleteItem}
-                onPause={this.pauseItem}
-              />
-            );
-          })
-        }
+        <DragDropContext onDragEnd={this.onDragEnd}>
+          <Droppable droppableId="droppable">
+            {(providedOuter) => (
+              <div
+                ref={providedOuter.innerRef}
+              >
+                {pendingItems && pendingItems.map((item, index) => (
+                  <Draggable key={item.key} draggableId={String(item.key)} index={index}>
+                    {(provided) => {
+                      return (
+                        <div>
+                          <div
+                            ref={provided.innerRef}
+                            {...provided.draggableProps}
+                          >
+                            <Item
+                              item={item}
+                              text={item.text}
+                              status={item.status}
+                              key={item.key}
+                              onComplete={this.completeItem}
+                              onDelete={this.props.deleteItem}
+                              onPause={this.pauseItem}
+                              dragHandleProps={provided.dragHandleProps}
+                            />
+                          </div>
+                          {provided.placeholder}
+                        </div>
+                    )}}
+                  </Draggable>
+                ))}
+              </div>
+            )}
+          </Droppable>
+        </DragDropContext>
         {this.renderPaused()}
         {this.renderReset()}
     </div>

--- a/views/components/ItemList.jsx
+++ b/views/components/ItemList.jsx
@@ -2,11 +2,11 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { addItem, updateItem, deleteItem, resetAll } from '../actions.js';
+import { addItem, updateItem, deleteItem, reorderItem, resetAll } from '../actions.js';
 import { getAllItems, getPendingItems, getCompletedItems, getPausedItems } from '../reducers/item-list.js';
 import Item from './Item';
 import Progress from './Progress';
-import { Droppable, Draggable } from 'react-beautiful-dnd';
+import { Droppable, Draggable, DragDropContext } from 'react-beautiful-dnd';
 
 class ItemList extends React.Component {
   constructor(props) {
@@ -14,6 +14,7 @@ class ItemList extends React.Component {
     this.addItem = this.addItem.bind(this);
     this.completeItem = this.completeItem.bind(this);
     this.pauseItem = this.pauseItem.bind(this);
+    this.onDragEnd = this.onDragEnd.bind(this);
   }
 
   addItem(e) {
@@ -108,9 +109,16 @@ class ItemList extends React.Component {
     ))
   }
 
+  onDragEnd({ source, destination }) {
+    console.log('onDragEnd');
+    if (!destination) return;
+    this.props.reorderItem(source, destination);
+  }
+
   render() {
     const { pendingItems, pausedItems } = this.props;
     return (
+      <DragDropContext onDragEnd={this.onDragEnd}>
         <div className="item-list">
           {this.renderProgress()}
           <form className="form" onSubmit={this.addItem}>
@@ -142,6 +150,7 @@ class ItemList extends React.Component {
           </Droppable>
           {this.renderReset()}
         </div>
+      </DragDropContext>
     );
   }
 }

--- a/views/components/ItemList.jsx
+++ b/views/components/ItemList.jsx
@@ -2,11 +2,11 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { addItem, updateItem, deleteItem, reorderItem, resetAll } from '../actions.js';
+import { addItem, updateItem, deleteItem, resetAll } from '../actions.js';
 import { getAllItems, getPendingItems, getCompletedItems, getPausedItems } from '../reducers/item-list.js';
 import Item from './Item';
 import Progress from './Progress';
-import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import { Droppable, Draggable } from 'react-beautiful-dnd';
 
 class ItemList extends React.Component {
   constructor(props) {
@@ -14,7 +14,6 @@ class ItemList extends React.Component {
     this.addItem = this.addItem.bind(this);
     this.completeItem = this.completeItem.bind(this);
     this.pauseItem = this.pauseItem.bind(this);
-    this.onDragEnd = this.onDragEnd.bind(this);
   }
 
   addItem(e) {
@@ -109,19 +108,9 @@ class ItemList extends React.Component {
     ))
   }
 
-  onDragEnd({ source, destination }) {
-    // dropped outside the list
-    if (!destination) {
-      return;
-    }
-
-    this.props.reorderItem(source, destination);
-  }
-
   render() {
     const { pendingItems, pausedItems } = this.props;
     return (
-      <DragDropContext onDragEnd={this.onDragEnd}>
         <div className="item-list">
           {this.renderProgress()}
           <form className="form" onSubmit={this.addItem}>
@@ -134,9 +123,7 @@ class ItemList extends React.Component {
           </form>
           <Droppable droppableId="pending">
             {(droppableProvided) => (
-              <div
-                ref={droppableProvided.innerRef}
-              >
+              <div ref={droppableProvided.innerRef} >
                 {this.renderItems(pendingItems)}
                 {droppableProvided.placeholder}
                 <div style={{ height: 20 }} />
@@ -144,11 +131,9 @@ class ItemList extends React.Component {
             )}
           </Droppable>
           <h2 style={{ margin: 0 }}>Do Later</h2>
-          <Droppable droppableId="paused">
+          <Droppable droppableId="paused" ignoreContainerClipping>
             {(droppableProvided) => (
-              <div
-                ref={droppableProvided.innerRef}
-              >
+              <div ref={droppableProvided.innerRef} >
                 <div style={{ height: 20 }} />
                 {this.renderItems(pausedItems)}
                 {droppableProvided.placeholder}
@@ -157,7 +142,6 @@ class ItemList extends React.Component {
           </Droppable>
           {this.renderReset()}
         </div>
-      </DragDropContext>
     );
   }
 }

--- a/views/components/ItemList.jsx
+++ b/views/components/ItemList.jsx
@@ -139,15 +139,17 @@ class ItemList extends React.Component {
               >
                 {this.renderItems(pendingItems)}
                 {droppableProvided.placeholder}
+                <div style={{ height: 20 }} />
               </div>
             )}
           </Droppable>
-          <h2>Do Later</h2>
+          <h2 style={{ margin: 0 }}>Do Later</h2>
           <Droppable droppableId="paused">
             {(droppableProvided) => (
               <div
                 ref={droppableProvided.innerRef}
               >
+                <div style={{ height: 20 }} />
                 {this.renderItems(pausedItems)}
                 {droppableProvided.placeholder}
               </div>

--- a/views/components/ItemList.jsx
+++ b/views/components/ItemList.jsx
@@ -110,7 +110,6 @@ class ItemList extends React.Component {
   }
 
   onDragEnd({ source, destination }) {
-    console.log('onDragEnd');
     if (!destination) return;
     this.props.reorderItem(source, destination);
   }
@@ -139,7 +138,7 @@ class ItemList extends React.Component {
             )}
           </Droppable>
           <h2 style={{ margin: 0 }}>Do Later</h2>
-          <Droppable droppableId="paused" ignoreContainerClipping>
+          <Droppable droppableId="paused">
             {(droppableProvided) => (
               <div ref={droppableProvided.innerRef} >
                 <div style={{ height: 20 }} />

--- a/views/main.jsx
+++ b/views/main.jsx
@@ -3,12 +3,38 @@
 import React from 'react';
 import Date from './components/Date';
 import ItemList from './components/ItemList';
+import { DragDropContext } from 'react-beautiful-dnd';
+import { connect } from 'react-redux';
+import { reorderItem } from './actions.js';
 
-export default class Main extends React.Component {
+class Main extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onDragEnd = this.onDragEnd.bind(this);
+  }
+
+  onDragEnd({ source, destination }) {
+    if (!destination) return;
+    this.props.reorderItem(source, destination);
+  }
+
   render() {
-    return <div>
-      <Date />
-      <ItemList />
-    </div>;
+    return (
+      <DragDropContext onDragEnd={this.onDragEnd}>
+        <div>
+          <Date />
+          <ItemList />
+        </div>
+      </DragDropContext>
+    );
   }
 }
+
+const mapStateToProps = () => ({});
+
+const mapDispatchToProps = dispatch => ({
+  reorderItem: (source, destination) => dispatch(reorderItem(source, destination)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Main);
+

--- a/views/main.jsx
+++ b/views/main.jsx
@@ -3,38 +3,17 @@
 import React from 'react';
 import Date from './components/Date';
 import ItemList from './components/ItemList';
-import { DragDropContext } from 'react-beautiful-dnd';
-import { connect } from 'react-redux';
-import { reorderItem } from './actions.js';
 
 class Main extends React.Component {
-  constructor(props) {
-    super(props);
-    this.onDragEnd = this.onDragEnd.bind(this);
-  }
-
-  onDragEnd({ source, destination }) {
-    if (!destination) return;
-    this.props.reorderItem(source, destination);
-  }
-
   render() {
     return (
-      <DragDropContext onDragEnd={this.onDragEnd}>
         <div>
           <Date />
           <ItemList />
         </div>
-      </DragDropContext>
     );
   }
 }
 
-const mapStateToProps = () => ({});
-
-const mapDispatchToProps = dispatch => ({
-  reorderItem: (source, destination) => dispatch(reorderItem(source, destination)),
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(Main);
+export default Main;
 

--- a/views/reducers/item-list.js
+++ b/views/reducers/item-list.js
@@ -1,8 +1,16 @@
-import { ADD_ITEM, UPDATE_ITEM, DELETE_ITEM, RESET_ALL } from '../actions';
+import { ADD_ITEM, UPDATE_ITEM, DELETE_ITEM, REORDER_ITEM, RESET_ALL } from '../actions';
 
 // initialize state
 const initialState = {
   items: []
+};
+
+const reorder = (list, startIndex, endIndex) => {
+  const result = Array.from(list);
+  const [removed] = result.splice(startIndex, 1);
+  result.splice(endIndex, 0, removed);
+
+  return result;
 };
 
 export default function(state = initialState, action) {
@@ -24,6 +32,9 @@ export default function(state = initialState, action) {
       break;
     case DELETE_ITEM:
       newState.items = newState.items.filter((item => item.key !== action.item.key));
+      break;
+    case REORDER_ITEM:
+      newState.items = reorder(newState.items, action.startIndex, action.endIndex);
       break;
     case RESET_ALL:
       newState.items = newState.items.filter(item => item.status !== 'complete').map(i => {

--- a/views/reducers/item-list.js
+++ b/views/reducers/item-list.js
@@ -5,11 +5,26 @@ const initialState = {
   items: []
 };
 
-const reorder = (list, startIndex, endIndex) => {
-  const result = Array.from(list);
-  const [removed] = result.splice(startIndex, 1);
-  result.splice(endIndex, 0, removed);
+// Move along the array until we have passed enough elements
+// of status 'destStatus' to place us at position 'destIndex'
+// within the filtered array, and return that index
+const findDestIndex = (list, destStatus, targetFilteredIndex) => {
+  let filteredIndex = 0;
+  const len = list.length;
+  for(let i = 0; i < len; i++) {
+    if(filteredIndex > targetFilteredIndex) return i - 1;
+    if(list[i].status === destStatus) filteredIndex++;
+  }
+  return len - 1;
+}
 
+const reorder = (list, source, destination) => {
+  const srcIndex = findDestIndex(list, source.droppableId, source.index);
+  const destIndex = findDestIndex(list, destination.droppableId, destination.index)
+  const result = Array.from(list);
+  const [removed] = result.splice(srcIndex, 1);
+  removed.status = destination.droppableId;
+  result.splice(destIndex, 0, removed);
   return result;
 };
 
@@ -34,7 +49,7 @@ export default function(state = initialState, action) {
       newState.items = newState.items.filter((item => item.key !== action.item.key));
       break;
     case REORDER_ITEM:
-      newState.items = reorder(newState.items, action.startIndex, action.endIndex);
+      newState.items = reorder(newState.items, action.source, action.destination);
       break;
     case RESET_ALL:
       newState.items = newState.items.filter(item => item.status !== 'complete').map(i => {


### PR DESCRIPTION
I've been wishing I could reorder the todos, so I took a stab at adding it.  You can drag items around within a list to reorder it, or drag it to/from the "Do Later" section to pause/unpause them.

![todometer-dragging-demo](https://user-images.githubusercontent.com/8581790/38904632-7f300212-4279-11e8-9219-ca50f8a825a7.gif)
