### PR TITLE
Stop breaking words in middle and scroll .item-name if necessary

### DIFF
--- a/styles/item.less
+++ b/styles/item.less
@@ -12,8 +12,9 @@
   box-sizing: border-box;
   font-size: @item-font-size;
   .item-name {
+    overflow: auto;
     width: 400px;
-    word-break: break-all;
+    word-break: normal;
   }
   .buttons button {
     position: relative;


### PR DESCRIPTION
Hi @cassidoo,

I'm taking part in Hacktoberfest this year and decided to make one of my PRs on your project. This is my take on fixing #58. It prevents breaking items in the middle of word and will scroll when an item name is extremely long. 

Example screenshot: 

<img width="912" alt="screen shot 2018-09-30 at 12 40 59 pm" src="https://user-images.githubusercontent.com/56848/46260707-f6df8f00-c4ae-11e8-9039-2129c9e16b69.png">
