### PR TITLE
Prevent break words and auto scroll item name if necessary

### DIFF
--- a/styles/item.less
+++ b/styles/item.less
@@ -13,7 +13,8 @@
   font-size: @item-font-size;
   .item-name {
     width: 400px;
-    word-break: break-all;
+	white-space: wrap;
+	overflow-x: auto;
   }
   .buttons button {
     position: relative;


### PR DESCRIPTION
Word break issue for #58  and #67 

Fix will not split words anymore, will just place in new line, and if word goes passed the .item-name width, it will give it an auto scroll!