### PR TITLE
Fix Windows Development

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "start": "rescripts start",
     "build": "rescripts build",
     "test": "rescripts test",
-    "electron-dev": "concurrently \"BROWSER=none yarn start\" \"wait-on http://localhost:3000 && electron .\"",
+    "electron-dev": "concurrently \"cross-env BROWSER=none yarn start\" \"wait-on http://localhost:3000 && electron .\"",
     "postinstall": "electron-builder install-app-deps",
     "pre-electron-pack": "yarn build",
     "electron-pack": "electron-builder build --dir --windows --mac --linux"
@@ -69,6 +69,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "concurrently": "^5.0.2",
+    "cross-env": "^7.0.0",
     "electron": "^7.1.10",
     "electron-builder": "^22.3.2",
     "node-sass": "^4.13.1",


### PR DESCRIPTION
The `BROWSER` environment variable isn't supported on Windows. Adding `cross-env` fixes local Electron development. I validated `yarn run electron-dev` runs successfully on macOS and Windows.