### PR TITLE
Disable contextIsolation

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -37,7 +37,8 @@ function createWindow() {
     backgroundColor: "#403F4D",
     icon: path.join(__dirname, "assets/png/128x128.png"),
     webPreferences: {
-      nodeIntegration: true
+      nodeIntegration: true,
+      contextIsolation: false
     }
   });
 


### PR DESCRIPTION
Changing the contextIsolation default in Electron 12.0 broke your build: https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-120

I'd consider this the "let's just get this working 🤠" solution whereas it's probably best to switch to an electron+vite starter and move away from rescripts. (I _really_ want to get my electron stuff off of webpack, but it's just not worth the hassle atm). I've been meaning to research what's available as far as vite starters, etc...

This does introduce some security concerns, but it's mostly "What happens if Electron opens a URL to a site that can hijack my computer!!!". 

Read more here: https://www.electronjs.org/docs/latest/tutorial/context-isolation