### PR TITLE
Add custom CSS theming with a theme picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 *.afdesign~lock~
+themes/*.png

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ See more in the Release documentation.
   - Notification preferences (reset notifications, reminder frequency)
   - Data vault location (move your database anywhere)
   - Display options (show/hide reset and copy buttons)
+  - Custom CSS override (point to your own `.css` file to restyle the app — changes apply live)
   - Local REST API and MCP server for external integrations
 - **[API & MCP integration](docs/api-and-mcp-setup.md)** — control todometer from scripts, shortcuts, or AI assistants
 - **Protocol handler** — add todos via `todometer://add?text=...` URLs

--- a/package.json
+++ b/package.json
@@ -69,6 +69,10 @@
 			{
 				"from": "src/mcp/index.mjs",
 				"to": "mcp/index.mjs"
+			},
+			{
+				"from": "themes",
+				"to": "themes"
 			}
 		],
 		"directories": {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -342,6 +342,145 @@ function notifyRendererDbChanged() {
 	}
 }
 
+// --- User-defined custom CSS override ---
+let customCssWatcher = null;
+let customCssWatchTimer = null;
+
+function getCustomCssState() {
+	return {
+		enabled: store.get("customCssEnabled") ?? false,
+		path: store.get("customCssPath") || null,
+	};
+}
+
+function readCustomCss() {
+	const { enabled, path: cssPath } = getCustomCssState();
+	if (!enabled || !cssPath) return "";
+	try {
+		return fs.readFileSync(cssPath, "utf8");
+	} catch (err) {
+		console.error("Failed to read custom CSS file:", err);
+		return "";
+	}
+}
+
+function getCustomCssPayload() {
+	const { enabled, path: cssPath } = getCustomCssState();
+	return { enabled, path: cssPath, css: readCustomCss() };
+}
+
+function broadcastCustomCss() {
+	if (hasMainWindow()) {
+		mainWindow.webContents.send("customCss:change", getCustomCssPayload());
+	}
+}
+
+function stopCustomCssWatcher() {
+	if (customCssWatcher) {
+		customCssWatcher.close();
+		customCssWatcher = null;
+	}
+}
+
+function startCustomCssWatcher() {
+	stopCustomCssWatcher();
+	const { enabled, path: cssPath } = getCustomCssState();
+	if (!enabled || !cssPath || !fs.existsSync(cssPath)) return;
+	try {
+		customCssWatcher = fs.watch(cssPath, { persistent: false }, () => {
+			// Debounce rapid successive change events emitted by editors.
+			clearTimeout(customCssWatchTimer);
+			customCssWatchTimer = setTimeout(broadcastCustomCss, 80);
+		});
+	} catch (err) {
+		console.error("Failed to watch custom CSS file:", err);
+	}
+}
+
+async function chooseCustomCssFile() {
+	if (!hasMainWindow()) return getCustomCssState();
+	const result = await dialog.showOpenDialog(mainWindow, {
+		title: "Choose custom CSS file",
+		properties: ["openFile"],
+		filters: [{ name: "CSS", extensions: ["css"] }],
+	});
+	if (result.canceled || !result.filePaths[0]) return getCustomCssState();
+	store.set("customCssPath", result.filePaths[0]);
+	store.set("customCssEnabled", true);
+	startCustomCssWatcher();
+	broadcastCustomCss();
+	return getCustomCssState();
+}
+
+function clearCustomCss() {
+	store.delete("customCssPath");
+	store.set("customCssEnabled", false);
+	stopCustomCssWatcher();
+	broadcastCustomCss();
+	return getCustomCssState();
+}
+
+function setCustomCssEnabled(enabled) {
+	store.set("customCssEnabled", !!enabled);
+	if (enabled) startCustomCssWatcher();
+	else stopCustomCssWatcher();
+	broadcastCustomCss();
+	return getCustomCssState();
+}
+
+// Directories scanned for drop-in theme .css files. The per-user themes
+// folder is listed first so user themes override bundled ones by name.
+function getThemeDirectories() {
+	const dirs = [];
+	const userThemes = path.join(app.getPath("userData"), "themes");
+	try {
+		fs.mkdirSync(userThemes, { recursive: true });
+	} catch (err) {
+		console.error("Failed to create user themes folder:", err);
+	}
+	dirs.push(userThemes);
+	dirs.push(
+		isDev
+			? path.join(app.getAppPath(), "themes")
+			: path.join(process.resourcesPath, "themes"),
+	);
+	return dirs;
+}
+
+function listThemes() {
+	const byName = new Map();
+	for (const dir of getThemeDirectories()) {
+		let entries = [];
+		try {
+			entries = fs.readdirSync(dir);
+		} catch {
+			continue;
+		}
+		for (const file of entries) {
+			if (!file.toLowerCase().endsWith(".css")) continue;
+			const name = file.replace(/\.css$/i, "");
+			if (!byName.has(name)) {
+				byName.set(name, { name, path: path.join(dir, file) });
+			}
+		}
+	}
+	return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function selectTheme(cssPath) {
+	if (!cssPath) return clearCustomCss();
+	store.set("customCssPath", cssPath);
+	store.set("customCssEnabled", true);
+	startCustomCssWatcher();
+	broadcastCustomCss();
+	return getCustomCssState();
+}
+
+function openThemesFolder() {
+	const [userThemes] = getThemeDirectories();
+	shell.openPath(userThemes);
+}
+
 function registerIpcHandlers() {
 	ipcMain.handle("db:loadState", () => {
 		return db.loadState();
@@ -503,6 +642,45 @@ function registerIpcHandlers() {
 		store.set("showCopyButton", show);
 		return show;
 	});
+
+	ipcMain.handle("settings:getCustomCss", () => {
+		return getCustomCssPayload();
+	});
+
+	ipcMain.handle("settings:chooseCustomCss", async () => {
+		await chooseCustomCssFile();
+		return getCustomCssPayload();
+	});
+
+	ipcMain.handle("settings:clearCustomCss", () => {
+		clearCustomCss();
+		return getCustomCssPayload();
+	});
+
+	ipcMain.handle("settings:toggleCustomCss", (_event, enable) => {
+		setCustomCssEnabled(enable);
+		return getCustomCssPayload();
+	});
+
+	ipcMain.handle("settings:revealCustomCss", () => {
+		const cssPath = store.get("customCssPath");
+		if (cssPath && fs.existsSync(cssPath)) {
+			shell.showItemInFolder(cssPath);
+		}
+	});
+
+	ipcMain.handle("settings:listThemes", () => {
+		return listThemes();
+	});
+
+	ipcMain.handle("settings:selectTheme", (_event, cssPath) => {
+		selectTheme(cssPath);
+		return getCustomCssPayload();
+	});
+
+	ipcMain.handle("settings:openThemesFolder", () => {
+		openThemesFolder();
+	});
 }
 
 function showNotification({ title, body, silent = false }) {
@@ -545,6 +723,9 @@ function createWindow() {
 					"file://" + __dirname,
 				).toString(),
 	);
+
+	mainWindow.webContents.on("did-finish-load", broadcastCustomCss);
+	startCustomCssWatcher();
 }
 
 function setupAutoUpdater() {

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -60,5 +60,21 @@ process.once("loaded", () => {
 			ipcRenderer.invoke("settings:getShowCopyButton"),
 		setShowCopyButton: (show) =>
 			ipcRenderer.invoke("settings:setShowCopyButton", show),
+		getCustomCss: () => ipcRenderer.invoke("settings:getCustomCss"),
+		chooseCustomCss: () => ipcRenderer.invoke("settings:chooseCustomCss"),
+		clearCustomCss: () => ipcRenderer.invoke("settings:clearCustomCss"),
+		toggleCustomCss: (enable) =>
+			ipcRenderer.invoke("settings:toggleCustomCss", enable),
+		revealCustomCss: () => ipcRenderer.invoke("settings:revealCustomCss"),
+		listThemes: () => ipcRenderer.invoke("settings:listThemes"),
+		selectTheme: (cssPath) =>
+			ipcRenderer.invoke("settings:selectTheme", cssPath),
+		openThemesFolder: () => ipcRenderer.invoke("settings:openThemesFolder"),
+	});
+
+	contextBridge.exposeInMainWorld("onCustomCssChange", (callback) => {
+		const listener = (_event, payload) => callback(payload);
+		ipcRenderer.on("customCss:change", listener);
+		return () => ipcRenderer.removeListener("customCss:change", listener);
 	});
 });

--- a/src/renderer/src/App.jsx
+++ b/src/renderer/src/App.jsx
@@ -3,11 +3,14 @@ import TodoDate from "./components/TodoDate.jsx";
 import ItemList from "./components/ItemList.jsx";
 import SettingsDrawer from "./components/SettingsDrawer.jsx";
 import { AppStateProvider } from "./AppContext.jsx";
+import { useCustomCss } from "./hooks/useCustomCss.js";
 
 function App() {
 	const [drawerOpen, setDrawerOpen] = useState(false);
 	const [showResetButton, setShowResetButton] = useState(true);
 	const [showCopyButton, setShowCopyButton] = useState(false);
+
+	useCustomCss();
 
 	useEffect(() => {
 		Promise.all([

--- a/src/renderer/src/components/SettingsDrawer.jsx
+++ b/src/renderer/src/components/SettingsDrawer.jsx
@@ -16,6 +16,8 @@ const SECTION_INFO = {
 	notifications: "Control how and when you receive notifications.",
 	data: "Manage where your data is stored.",
 	display: "Enable extra buttons on the interface.",
+	appearance:
+		"Pick a theme from your themes folder. Drop a .css file into the folder to add your own; changes apply live.",
 	api: "Query and control your todometer data from other applications using the local API.",
 };
 
@@ -73,18 +75,28 @@ function SettingsDrawer({
 	});
 	const [tokenCopied, setTokenCopied] = useState(false);
 	const [mcpCopied, setMcpCopied] = useState(false);
+	const [customCss, setCustomCss] = useState({
+		enabled: false,
+		path: null,
+		css: "",
+	});
+	const [themes, setThemes] = useState([]);
 
 	const loadSettings = useCallback(async () => {
 		if (!window.settingsAPI) return;
 		try {
-			const [notif, vault, api] = await Promise.all([
+			const [notif, vault, api, css, themeList] = await Promise.all([
 				window.settingsAPI.getNotifications(),
 				window.settingsAPI.getVaultPath(),
 				window.settingsAPI.getApiState(),
+				window.settingsAPI.getCustomCss(),
+				window.settingsAPI.listThemes(),
 			]);
 			setNotifications(notif);
 			setVaultInfo(vault);
 			setApiState(api);
+			setCustomCss(css);
+			setThemes(themeList ?? []);
 		} catch (err) {
 			console.error("Failed to load settings:", err);
 		}
@@ -174,8 +186,31 @@ function SettingsDrawer({
 		window.settingsAPI?.setShowCopyButton(newValue);
 	}
 
+	async function handleThemeChange(e) {
+		const value = e.target.value;
+		const result = await window.settingsAPI?.selectTheme(value);
+		if (result) setCustomCss(result);
+	}
+
+	function handleOpenThemesFolder() {
+		window.settingsAPI?.openThemesFolder();
+	}
+
 	const displayPath = vaultInfo.path || vaultInfo.currentPath || "Default";
 	const isCustomVault = !!vaultInfo.path;
+	const selectedThemePath =
+		customCss.enabled && customCss.path ? customCss.path : "";
+	const themeOptions = [...themes];
+	if (
+		selectedThemePath &&
+		!themeOptions.some((t) => t.path === selectedThemePath)
+	) {
+		const base = selectedThemePath
+			.split(/[\\/]/)
+			.pop()
+			.replace(/\.css$/i, "");
+		themeOptions.unshift({ name: `${base} (custom)`, path: selectedThemePath });
+	}
 	const mcpJson = JSON.stringify(
 		{
 			mcpServers: {
@@ -295,6 +330,32 @@ function SettingsDrawer({
 								/>
 								<span className={styles.slider} />
 							</label>
+						</section>
+
+						<section className={styles.section}>
+							<div className={styles.sectionHeader}>
+								<h3>Appearance</h3>
+								<InfoButton text={SECTION_INFO.appearance} />
+							</div>
+							<div className={styles.field}>
+								<span>Theme</span>
+								<select value={selectedThemePath} onChange={handleThemeChange}>
+									<option value="">Default</option>
+									{themeOptions.map((theme) => (
+										<option key={theme.path} value={theme.path}>
+											{theme.name}
+										</option>
+									))}
+								</select>
+							</div>
+							<div className={styles.buttonGroup}>
+								<button
+									className={styles.secondaryButton}
+									onClick={handleOpenThemesFolder}
+								>
+									Open themes folder…
+								</button>
+							</div>
 						</section>
 
 						<section className={styles.section}>

--- a/src/renderer/src/hooks/useCustomCss.js
+++ b/src/renderer/src/hooks/useCustomCss.js
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+
+const STYLE_ELEMENT_ID = "user-custom-css";
+
+function applyCustomCss(payload) {
+	const css = payload?.enabled ? (payload.css ?? "") : "";
+	let styleEl = document.getElementById(STYLE_ELEMENT_ID);
+
+	if (!css) {
+		if (styleEl) styleEl.remove();
+		return;
+	}
+
+	if (!styleEl) {
+		styleEl = document.createElement("style");
+		styleEl.id = STYLE_ELEMENT_ID;
+		document.head.appendChild(styleEl);
+	}
+	styleEl.textContent = css;
+}
+
+// Injects and live-updates a user-defined CSS override supplied via the
+// settings drawer. The stylesheet is appended last so it wins over the
+// bundled component styles.
+export function useCustomCss() {
+	useEffect(() => {
+		window.settingsAPI
+			?.getCustomCss()
+			.then(applyCustomCss)
+			.catch((err) => console.error("Failed to load custom CSS:", err));
+
+		const removeListener = window?.onCustomCssChange?.(applyCustomCss);
+		return () => {
+			if (typeof removeListener === "function") removeListener();
+		};
+	}, []);
+}

--- a/themes/dracula.css
+++ b/themes/dracula.css
@@ -1,0 +1,55 @@
+/*
+ * Dracula — the classic dark palette for todometer.
+ * https://draculatheme.com
+ * Pick it in Settings → Configuration → Appearance → Theme.
+ */
+
+:root {
+	--bg: #282a36;
+	--green: #50fa7b;
+	--yellow: #f1fa8c;
+	--red: #ff5555;
+	--gray: #6272a4;
+	--highlight: rgba(189, 147, 249, 0.18);
+
+	--input-color: #343746;
+	--item-color: #383a4c;
+	--font-color: #f8f8f2;
+
+	--big-font-size: 64px;
+	--heading-font-size: 24px;
+	--item-font-size: 20px;
+	--pulse-animation: click 0.5s;
+}
+
+body {
+	font-family: "Fira Code", "JetBrains Mono", "Consolas", monospace !important;
+	letter-spacing: 0.2px;
+	background: var(--bg) !important;
+}
+
+::selection {
+	background: #bd93f9;
+	color: #282a36;
+}
+
+input,
+textarea,
+button,
+select {
+	font-family: "Fira Code", "JetBrains Mono", "Consolas", monospace !important;
+}
+
+::placeholder {
+	color: var(--gray);
+}
+
+input:focus,
+textarea:focus {
+	box-shadow: 0 0 0 1px #bd93f9;
+}
+
+.today::after {
+	content: " ●";
+	color: #bd93f9;
+}

--- a/themes/hacker-terminal.css
+++ b/themes/hacker-terminal.css
@@ -1,0 +1,111 @@
+/*
+ * Hacker Terminal — a neon-green CRT theme for todometer.
+ *
+ * Drop-in override: Settings → Configuration → Appearance → Custom CSS →
+ * "Choose…" this file. It re-maps todometer's design tokens and layers on
+ * some terminal flair (monospace, phosphor glow, blinking caret, scanlines).
+ */
+
+:root {
+	--bg: #050805;
+	--green: #00ff41;
+	--yellow: #f9f871;
+	--red: #ff073a;
+	--gray: rgba(0, 255, 65, 0.45);
+	--highlight: rgba(0, 255, 65, 0.12);
+
+	--input-color: #0a120a;
+	--item-color: #0b160b;
+	--font-color: #00ff41;
+
+	--big-font-size: 64px;
+	--heading-font-size: 24px;
+	--item-font-size: 20px;
+	--pulse-animation: click 0.5s;
+}
+
+body {
+	font-family: "Cascadia Code", "Fira Code", "JetBrains Mono", "Consolas",
+		"Courier New", monospace !important;
+	letter-spacing: 0.5px;
+	text-shadow: 0 0 4px rgba(0, 255, 65, 0.55);
+	background:
+		radial-gradient(circle at 50% -10%, rgba(0, 255, 65, 0.08), transparent 55%),
+		var(--bg) !important;
+}
+
+::selection {
+	background: var(--green);
+	color: #001a05;
+	text-shadow: none;
+}
+
+/* Inputs / buttons: phosphor glow + focus ring */
+input,
+textarea,
+button,
+select {
+	font-family: "Cascadia Code", "Fira Code", "JetBrains Mono", "Consolas",
+		"Courier New", monospace !important;
+	text-shadow: 0 0 4px rgba(0, 255, 65, 0.5);
+}
+
+/* Match the placeholder hint to the monospace input text */
+::placeholder {
+	font-family: "Cascadia Code", "Fira Code", "JetBrains Mono", "Consolas",
+		"Courier New", monospace;
+}
+
+input:focus,
+textarea:focus {
+	box-shadow:
+		0 0 0 1px var(--green),
+		0 0 12px rgba(0, 255, 65, 0.25) inset;
+}
+
+/* Blinking terminal caret after the weekday label (global .today class) */
+.today::after {
+	content: " _";
+	animation: hk-blink 1s steps(1) infinite;
+	color: var(--green);
+}
+
+@keyframes hk-blink {
+	50% {
+		opacity: 0;
+	}
+}
+
+/* CRT scanlines + subtle flicker overlay */
+body::after {
+	content: "";
+	position: fixed;
+	inset: 0;
+	pointer-events: none;
+	z-index: 9999;
+	background: repeating-linear-gradient(
+		to bottom,
+		rgba(0, 0, 0, 0) 0,
+		rgba(0, 0, 0, 0) 2px,
+		rgba(0, 0, 0, 0.22) 3px,
+		rgba(0, 0, 0, 0.22) 3px
+	);
+	mix-blend-mode: multiply;
+	animation: hk-flicker 4s infinite;
+}
+
+@keyframes hk-flicker {
+	0%,
+	100% {
+		opacity: 0.8;
+	}
+	48% {
+		opacity: 0.72;
+	}
+	50% {
+		opacity: 0.9;
+	}
+	52% {
+		opacity: 0.74;
+	}
+}

--- a/themes/nord.css
+++ b/themes/nord.css
@@ -1,0 +1,55 @@
+/*
+ * Nord — a calm, arctic, north-bluish palette for todometer.
+ * https://www.nordtheme.com
+ * Pick it in Settings → Configuration → Appearance → Theme.
+ */
+
+:root {
+	--bg: #2e3440;
+	--green: #a3be8c;
+	--yellow: #ebcb8b;
+	--red: #bf616a;
+	--gray: #4c566a;
+	--highlight: rgba(136, 192, 208, 0.18);
+
+	--input-color: #3b4252;
+	--item-color: #434c5e;
+	--font-color: #eceff4;
+
+	--big-font-size: 64px;
+	--heading-font-size: 24px;
+	--item-font-size: 20px;
+	--pulse-animation: click 0.5s;
+}
+
+body {
+	font-family: "Inter", "Segoe UI", "Helvetica Neue", sans-serif !important;
+	letter-spacing: 0.2px;
+	background: var(--bg) !important;
+}
+
+::selection {
+	background: #88c0d0;
+	color: #2e3440;
+}
+
+input,
+textarea,
+button,
+select {
+	font-family: "Inter", "Segoe UI", "Helvetica Neue", sans-serif !important;
+}
+
+::placeholder {
+	color: #7b88a1;
+}
+
+input:focus,
+textarea:focus {
+	box-shadow: 0 0 0 1px #88c0d0;
+}
+
+.today::after {
+	content: " ❄";
+	color: #88c0d0;
+}

--- a/themes/paper-light.css
+++ b/themes/paper-light.css
@@ -1,0 +1,65 @@
+/*
+ * Paper Light — a warm, printed-notebook light theme for todometer.
+ * Pick it in Settings → Configuration → Appearance → Theme.
+ */
+
+:root {
+	--bg: #f4f1ea;
+	--green: #4f7d4a;
+	--yellow: #c08a2d;
+	--red: #b0413e;
+	--gray: #9a9385;
+	--highlight: rgba(79, 125, 74, 0.14);
+
+	--input-color: #ece7db;
+	--item-color: #efeae0;
+	--font-color: #2e2a24;
+
+	--big-font-size: 64px;
+	--heading-font-size: 24px;
+	--item-font-size: 20px;
+	--pulse-animation: click 0.5s;
+}
+
+body {
+	font-family: "Iowan Old Style", "Palatino Linotype", Georgia, "Times New Roman",
+		serif !important;
+	letter-spacing: 0.2px;
+	color: var(--font-color);
+	background:
+		repeating-linear-gradient(
+			to bottom,
+			transparent 0,
+			transparent 31px,
+			rgba(46, 42, 36, 0.06) 32px
+		),
+		var(--bg) !important;
+}
+
+::selection {
+	background: #d8cbb0;
+	color: #2e2a24;
+}
+
+input,
+textarea,
+button,
+select {
+	font-family: "Iowan Old Style", "Palatino Linotype", Georgia, "Times New Roman",
+		serif !important;
+	color: var(--font-color);
+}
+
+::placeholder {
+	color: var(--gray);
+}
+
+input:focus,
+textarea:focus {
+	box-shadow: 0 0 0 1px var(--green);
+}
+
+.today::after {
+	content: " ✎";
+	color: var(--green);
+}

--- a/themes/synthwave.css
+++ b/themes/synthwave.css
@@ -1,0 +1,64 @@
+/*
+ * Synthwave — an '80s neon sunset theme for todometer.
+ * Drop this file into your themes folder and pick it in
+ * Settings → Configuration → Appearance → Theme.
+ */
+
+:root {
+	--bg: #1a1033;
+	--green: #05ffa1;
+	--yellow: #fee440;
+	--red: #ff2e97;
+	--gray: rgba(255, 255, 255, 0.45);
+	--highlight: rgba(255, 46, 151, 0.18);
+
+	--input-color: #2a1a4a;
+	--item-color: #241546;
+	--font-color: #f7f0ff;
+
+	--big-font-size: 64px;
+	--heading-font-size: 24px;
+	--item-font-size: 20px;
+	--pulse-animation: click 0.5s;
+}
+
+body {
+	font-family: "Poppins", "Segoe UI", "Helvetica Neue", sans-serif !important;
+	letter-spacing: 0.3px;
+	text-shadow: 0 0 6px rgba(255, 46, 151, 0.35);
+	background:
+		linear-gradient(
+			180deg,
+			#2b1055 0%,
+			#41197a 45%,
+			#7b1e6d 75%,
+			#ff2e97 140%
+		),
+		var(--bg) !important;
+}
+
+::selection {
+	background: var(--red);
+	color: #1a1033;
+	text-shadow: none;
+}
+
+input,
+textarea,
+button,
+select {
+	font-family: "Poppins", "Segoe UI", "Helvetica Neue", sans-serif !important;
+}
+
+input:focus,
+textarea:focus {
+	box-shadow:
+		0 0 0 1px var(--red),
+		0 0 12px rgba(5, 255, 161, 0.25) inset;
+}
+
+.today::after {
+	content: " ▲";
+	color: var(--green);
+	text-shadow: 0 0 8px rgba(5, 255, 161, 0.6);
+}


### PR DESCRIPTION
## Summary

Adds optional theming to todometer. A **Theme** dropdown in Settings -> Configuration -> Appearance lists `.css` files found in the app's themes folders and applies the selected one live. Users can drop their own `.css` into the per-user themes folder to add themes without rebuilding.

## What's included

- **Theme picker** in the Settings drawer (dropdown + "Open themes folder...").
- **Theme discovery** scans a per-user folder (`userData/themes`) and the bundled `themes/` folder, deduped by name (user themes win).
- **Live reload** - editing the active theme file re-applies it via `fs.watch`.
- **5 bundled themes**: hacker-terminal, synthwave, dracula, nord, paper-light.
- Themes shipped in packaged builds via `build.extraResources`.

## How it works

Themes re-map the existing design tokens in `variables.css` (`--bg`, `--green`, `--font-color`, etc.) plus a few global element selectors, so no component styles need to change. The renderer injects the selected CSS as a trailing `<style>` tag so it overrides bundled styles.

## Notes

- No change to existing behavior when no theme is selected (defaults to "Default").
